### PR TITLE
Call template with nice fetch method

### DIFF
--- a/ps_currencyselector.php
+++ b/ps_currencyselector.php
@@ -102,6 +102,6 @@ class Ps_Currencyselector extends Module implements WidgetInterface
 			return '';
 
 		$this->smarty->assign($this->getWidgetVariables($hookName, $configuration));
-		return $this->display(__FILE__, 'ps_currencyselector.tpl');
+		return $this->fetch('module:ps_currencyselector/ps_currencyselector.tpl');
 	}
 }


### PR DESCRIPTION
`$this->display()` should not be used anymore!

Have a look at this: https://github.com/PrestaShop/PrestaShop/pull/6491
