### PR TITLE
Remove cache

### DIFF
--- a/ps_currencyselector.php
+++ b/ps_currencyselector.php
@@ -112,10 +112,8 @@ class Ps_Currencyselector extends Module implements WidgetInterface
             return false;
         }
 
-        if (!$this->isCached($this->templateFile, $this->getCacheId('ps_currencyselector'))) {
-            $this->smarty->assign($this->getWidgetVariables($hookName, $configuration));
-        }
+        $this->smarty->assign($this->getWidgetVariables($hookName, $configuration));
 
-        return $this->fetch($this->templateFile, $this->getCacheId('ps_currencyselector'));
+        return $this->fetch($this->templateFile);
     }
 }


### PR DESCRIPTION
The same issue as ps_languageselector. The cache was keeping the current link the first time it is built.
We have to remove the cache so that we always use the current link and not the one from the cache.

http://forge.prestashop.com/browse/BOOM-1975