### PR TITLE
Rebuild the url to avoid doublons

### DIFF
--- a/ps_currencyselector.php
+++ b/ps_currencyselector.php
@@ -88,9 +88,10 @@ class Ps_Currencyselector extends Module implements WidgetInterface
                         'id_currency' => $currency->id,
                     )
                 );
-                $newUrl = sprintf('%s://%s%s?%s',
+                $newUrl = sprintf('%s://%s%s%s?%s',
                     $parsedUrl['scheme'],
                     $parsedUrl['host'],
+                    isset($parsedUrl['port']) ? ':' . $parsedUrl['port'] : '',
                     $parsedUrl['path'],
                     http_build_query($newParams)
                 );

--- a/ps_currencyselector.php
+++ b/ps_currencyselector.php
@@ -76,17 +76,26 @@ class Ps_Currencyselector extends Module implements WidgetInterface
 
                 $url = $this->context->link->getLanguageLink($this->context->language->id);
 
-                $extraParams = array(
-                    'SubmitCurrency' => 1,
-                    'id_currency' => $currency->id
+                $parsedUrl = parse_url($url);
+                $urlParams = array();
+                if (isset($parsedUrl['query'])) {
+                    parse_str($parsedUrl['query'], $urlParams);
+                }
+                $newParams = array_merge(
+                    $urlParams,
+                    array(
+                        'SubmitCurrency' => 1,
+                        'id_currency' => $currency->id,
+                    )
+                );
+                $newUrl = sprintf('%s://%s%s?%s',
+                    $parsedUrl['scheme'],
+                    $parsedUrl['host'],
+                    $parsedUrl['path'],
+                    http_build_query($newParams)
                 );
 
-                $partialQueryString = http_build_query($extraParams);
-                $separator = empty(parse_url($url)['query']) ? '?' : '&';
-
-                $url .= $separator . $partialQueryString;
-
-                $currencyArray['url'] = $url;
+                $currencyArray['url'] = $newUrl;
 
                 if ($currency->id === $this->context->currency->id) {
                     $currencyArray['current'] = true;


### PR DESCRIPTION
Rebuild the url with extra parameters instead of concatenating them to avoid doublons

As explained in this issue https://github.com/PrestaShop/PrestaShop/pull/16378

The currency url sometimes had parameters in doublons (only saw it on homepage but maybe in other places as well) this caused a loop in search engine robots
This PR changes the way the url is built so that the extra parameters are now unique
