### PR TITLE
Add condition to avoid duplicate currency name

### DIFF
--- a/ps_currencyselector.tpl
+++ b/ps_currencyselector.tpl
@@ -28,7 +28,7 @@
   <ul>
     {foreach from=$currencies item=currency}
       <li {if $currency.current} class="current" {/if}>
-        <a rel="nofollow" href="{$currency.url}">{$currency.iso_code}{if $currency.sign !== $currency.iso_code} {$currency.sign}</a>
+        <a rel="nofollow" href="{$currency.url}">{$currency.iso_code}{if $currency.sign !== $currency.iso_code} {$currency.sign}{/if}</a>
       </li>
     {/foreach}
   </ul>

--- a/ps_currencyselector.tpl
+++ b/ps_currencyselector.tpl
@@ -24,11 +24,11 @@
 *}
 
 <div class="currency-selector">
-  <span>{$current_currency.iso_code} {$current_currency.sign}</span>
+  <span>{$current_currency.iso_code}{if $current_currency.sign !== $current_currency.iso_code} {$current_currency.sign}{/if}</span>
   <ul>
     {foreach from=$currencies item=currency}
       <li {if $currency.current} class="current" {/if}>
-        <a rel="nofollow" href="{$currency.url}">{$currency.iso_code} {$currency.sign}</a>
+        <a rel="nofollow" href="{$currency.url}">{$currency.iso_code}{if $currency.sign !== $currency.iso_code} {$currency.sign}</a>
       </li>
     {/foreach}
   </ul>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | On currency which has the same ISO Code as their sign, we see a duplicate name on the top selector
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/PrestaShop#9692.
| How to test?  | Create a currency which as TEST as iso code and TEST as sign, see if it's duplicate on FO

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18739)
<!-- Reviewable:end -->
