### PR TITLE
Replace deprecated ObjectPresenter namespace

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        presta-versions: ['1.7.4.4', '1.7.5.1', '1.7.6', '1.7.7', '1.7.8', 'latest']
+        presta-versions: ['1.7.5.1', '1.7.6', '1.7.7', '1.7.8', 'latest']
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        presta-versions: ['1.7.1.2', '1.7.2.5', '1.7.3.4', '1.7.4.4', '1.7.5.1', '1.7.6', '1.7.7', '1.7.8', 'latest']
+        presta-versions: ['1.7.4.4', '1.7.5.1', '1.7.6', '1.7.7', '1.7.8', 'latest']
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/ps_currencyselector.php
+++ b/ps_currencyselector.php
@@ -48,7 +48,7 @@ class Ps_Currencyselector extends Module implements WidgetInterface
         $this->displayName = $this->trans('Currency block', [], 'Modules.Currencyselector.Admin');
         $this->description = $this->trans('Offer your customers the possibility to buy matching items when on a product page.', [], 'Modules.Currencyselector.Admin');
 
-        $this->ps_versions_compliancy = ['min' => '1.7.4.0', 'max' => _PS_VERSION_];
+        $this->ps_versions_compliancy = ['min' => '1.7.5.0', 'max' => _PS_VERSION_];
 
         $this->templateFile = 'module:ps_currencyselector/ps_currencyselector.tpl';
     }

--- a/ps_currencyselector.php
+++ b/ps_currencyselector.php
@@ -24,7 +24,7 @@
 *  International Registered Trademark & Property of PrestaShop SA
 */
 
-use PrestaShop\PrestaShop\Adapter\ObjectPresenter;
+use PrestaShop\PrestaShop\Adapter\Presenter\Object\ObjectPresenter;
 use PrestaShop\PrestaShop\Core\Module\WidgetInterface;
 
 if (!defined('_PS_VERSION_')) {
@@ -40,7 +40,7 @@ class Ps_Currencyselector extends Module implements WidgetInterface
         $this->name = 'ps_currencyselector';
         $this->tab = 'front_office_features';
         $this->author = 'PrestaShop';
-        $this->version = '2.0.1';
+        $this->version = '2.1.0';
         $this->need_instance = 0;
 
         parent::__construct();
@@ -48,7 +48,7 @@ class Ps_Currencyselector extends Module implements WidgetInterface
         $this->displayName = $this->trans('Currency block', [], 'Modules.Currencyselector.Admin');
         $this->description = $this->trans('Offer your customers the possibility to buy matching items when on a product page.', [], 'Modules.Currencyselector.Admin');
 
-        $this->ps_versions_compliancy = ['min' => '1.7.1.0', 'max' => _PS_VERSION_];
+        $this->ps_versions_compliancy = ['min' => '1.7.4.0', 'max' => _PS_VERSION_];
 
         $this->templateFile = 'module:ps_currencyselector/ps_currencyselector.tpl';
     }
@@ -59,7 +59,7 @@ class Ps_Currencyselector extends Module implements WidgetInterface
             && $this->registerHook('actionAdminCurrenciesControllerSaveAfter');
     }
 
-    public function hookActionAdminCurrenciesControllerSaveAfter($params)
+    public function hookActionAdminCurrenciesControllerSaveAfter()
     {
         return parent::_clearCache($this->templateFile);
     }

--- a/tests/phpstan/phpstan-1.7.1.2.neon
+++ b/tests/phpstan/phpstan-1.7.1.2.neon
@@ -1,6 +1,0 @@
-includes:
-	- %currentWorkingDirectory%/tests/phpstan/phpstan.neon
-
-parameters:
-  ignoreErrors:
-    - '#Call to method assign\(\) on an unknown class Smarty_Data#'

--- a/tests/phpstan/phpstan-1.7.2.5.neon
+++ b/tests/phpstan/phpstan-1.7.2.5.neon
@@ -1,6 +1,0 @@
-includes:
-	- %currentWorkingDirectory%/tests/phpstan/phpstan.neon
-
-parameters:
-  ignoreErrors:
-    - '#Call to method assign\(\) on an unknown class Smarty_Data#'

--- a/tests/phpstan/phpstan-1.7.3.4.neon
+++ b/tests/phpstan/phpstan-1.7.3.4.neon
@@ -1,6 +1,0 @@
-includes:
-	- %currentWorkingDirectory%/tests/phpstan/phpstan.neon
-
-parameters:
-  ignoreErrors:
-    - '#Call to method assign\(\) on an unknown class Smarty_Data#'

--- a/tests/phpstan/phpstan-1.7.4.4.neon
+++ b/tests/phpstan/phpstan-1.7.4.4.neon
@@ -1,2 +1,0 @@
-includes:
-	- %currentWorkingDirectory%/tests/phpstan/phpstan.neon


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Title says it all
| Type?         | refacto
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | Everything is supposed to work as before, the behavior is kept identicail. The changed code is related to displaying currency list in Front office.
| Sponsor company | impSolutions

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
